### PR TITLE
Update instaloader.sh

### DIFF
--- a/instaloader.sh
+++ b/instaloader.sh
@@ -37,7 +37,7 @@ display_options() {
 # Function to download profile pictures
 download_profile_pictures() {
     read -p "Enter the username: " username
-    instaloader --no-videos --no-metadata-json --no-captions --no-compress-json profile $username
+    instaloader --no-videos --no-metadata-json --no-captions --no-compress-json --no-posts $username
 }
 
 # Function to download all posts by a user


### PR DESCRIPTION
In download_profile_pictures() function, after entering username it's download the profile picture and also all post of that username. 

I just add --no-posts command and remove the profile text from download_profile_pictures() function